### PR TITLE
add support for client_charset definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ If you want to configure some server add them to your node's attributes:
         'host'=> 'ntmachine.domain.com',
         'port' => 1433,
         'tds_version' => '7.0',
-        'text_size' => 1024
+        'text_size' => 1024,
+        'client_charset' => 'UTF-8'
       }
     ]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['freetds']['packages']       = %w(freetds-bin freetds-dev)
 default['freetds']['tds_version']    = '7.1'
 default['freetds']['odbc']           = false
 default['freetds']['text_size']      = 64_512
+default['freetds']['client_charset'] = nil
 
 case node['freetds']['install_method']
 when 'package'
@@ -45,6 +46,7 @@ default['freetds']['servers'] = [
     'description' => 'A typical Microsoft server',
     'host' => 'ntmachine.domain.com',
     'port' => 1433,
-    'tds_version' => '7.0'
+    'tds_version' => '7.0',
+    'client_charset' => 'UTF-8'
   }
 ]

--- a/templates/default/freetds.conf.erb
+++ b/templates/default/freetds.conf.erb
@@ -1,10 +1,10 @@
 #   $Id: freetds.conf,v 1.12 2007/12/25 06:02:36 jklowden Exp $
 #
-# This file is installed by FreeTDS if no file by the same 
-# name is found in the installation directory.  
+# This file is installed by FreeTDS if no file by the same
+# name is found in the installation directory.
 #
-# For information about the layout of this file and its settings, 
-# see the freetds.conf manpage "man freetds.conf".  
+# For information about the layout of this file and its settings,
+# see the freetds.conf manpage "man freetds.conf".
 
 # Global settings are overridden by those in a database
 # server specific section
@@ -20,10 +20,10 @@
 	# Command and connection timeouts
 ;	timeout = 10
 ;	connect timeout = 10
-	
+
 	# If you get out-of-memory errors, it may mean that your client
-	# is trying to allocate a huge buffer for a TEXT field.  
-	# Try setting 'text size' to a more reasonable limit 
+	# is trying to allocate a huge buffer for a TEXT field.
+	# Try setting 'text size' to a more reasonable limit
 	text size = <%= node['freetds']['text_size'] %>
 <% @node['freetds']['servers'].each do |server|%>
 
@@ -33,10 +33,13 @@
 [<%= server['name']%>]
 	host = <%= server['host'] %>
 	port = <%= server['port'] || 1433 %>
-<% if server['tds_version'] %>  
+<% if server['tds_version'] %>
 	tds version = <%= server['tds_version'] %>
 <% end %>
 <% if server['text_size'] %>
 	text size = <%= server['text_size'] %>
+<% end %>
+<% if server['client_charset'] %>
+	client charset = <%= server['client_charset'] %>
 <% end %>
 <% end %>


### PR DESCRIPTION
simple support to specify client charset in the global freetds configuration file. Won't add a default client charset to prevent any issue when updating without defining a default charset.